### PR TITLE
fix: 修复 从Markdown导入 中的格式错误

### DIFF
--- a/docs/notes/transfer/markdown-import.md
+++ b/docs/notes/transfer/markdown-import.md
@@ -29,11 +29,12 @@ Mizuki 文章的核心是 Markdown 文件，但需要包含特定的 Frontmatter
 
 ## 小标题
 
-更多内容...
+更多内容... 
+
 ```
 
 ### Mizuki 格式示例：
-```yaml
+<!-- ```markdown
 ---
 title: Markdown Tutorial
 published: 2025-01-20
@@ -46,8 +47,11 @@ author: emn178
 sourceLink: "https://github.com/emn178/markdown"
 draft: false
 ---
+``` -->
 
-```yaml
+
+```markdown
+---
 title: "我的第一篇文章"
 pubDate: 2024-01-15
 updatedDate: 2024-01-16
@@ -56,7 +60,8 @@ tags: ["技术", "教程"]
 category: "技术分享"
 cover: "/images/cover.jpg"
 draft: false
-```
+---
+
 # 我的第一篇文章
 
 这是一篇纯 Markdown 格式的文章内容。


### PR DESCRIPTION
修复 从Markdown导入 中的格式错误，完善文档可读性。
修复前： <img width="1099" height="916" alt="image" src="https://github.com/user-attachments/assets/4e2a79bb-c870-4577-9054-c17567b21fa3" />

修复后： 
<img width="980" height="948" alt="image" src="https://github.com/user-attachments/assets/5150002d-2dcc-459c-992f-a570dcaa58ff" />
